### PR TITLE
Stretch the content more accurately

### DIFF
--- a/components/Stretch/Stretch.module.css
+++ b/components/Stretch/Stretch.module.css
@@ -1,0 +1,10 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: stretch;
+}
+
+.container > *:nth-child(2) {
+  flex-grow: 1;
+}

--- a/components/Stretch/Stretch.module.css
+++ b/components/Stretch/Stretch.module.css
@@ -1,10 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   min-height: 100vh;
   min-height: stretch;
-}
-
-.container > *:nth-child(2) {
-  flex-grow: 1;
 }

--- a/components/Stretch/Stretch.tsx
+++ b/components/Stretch/Stretch.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import styles from "./Stretch.module.css";
+
+export const Stretch: React.FC = ({ children }) => {
+  return <div className={styles.container}>{children}</div>;
+};

--- a/components/Stretch/index.ts
+++ b/components/Stretch/index.ts
@@ -1,0 +1,1 @@
+export * from "./Stretch";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import Head from "next/head";
+
+import { Stretch } from "@components/Stretch";
 import { Header } from "@components/Header";
 import { Footer } from "@components/Footer";
 import { Center } from "@components/Center";
@@ -19,14 +21,18 @@ import "@shared/styles/rhythm.css";
 export default function MyApp({ Component, pageProps }) {
   return (
     <Center>
-      <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
-      <div className="wrap">
-        <Header />
-        <Component {...pageProps} />
-      </div>
-      <Footer />
+      <Stretch>
+        <Head>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
+        </Head>
+
+        <div className="content">
+          <Header />
+          <Component {...pageProps} />
+        </div>
+
+        <Footer />
+      </Stretch>
     </Center>
   );
 }

--- a/shared/styles/global.css
+++ b/shared/styles/global.css
@@ -53,8 +53,3 @@ a:hover {
   color: var(--link-accent-color);
   text-decoration-color: var(--decoration-accent-color);
 }
-
-.wrap {
-  min-height: 100vh;
-  min-height: calc(100vh - var(--footer-height));
-}


### PR DESCRIPTION
Stop depending on the difference between `100vh` and a `--footer-height` since it isn't accurate in iOS Safari. Instead, use the flexbox to deal with spacing between the content and the footer.

Inside, the `Stretch` component uses `height: stretch` to determine how much space it should occupy and lays out its inner nodes according to `flex` spec.