### PR TITLE
Encapsulate services' structure

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -6,6 +6,7 @@
   "moduleNameMapper": {
     "^@core(.*)$": "<rootDir>/src/core$1",
 
+    "^@services(.*)$": "<rootDir>/src/services$1",
     "^@network(.*)$": "<rootDir>/src/services/network$1",
     "^@persistence(.*)$": "<rootDir>/src/services/persistence$1",
 

--- a/jest.config.json
+++ b/jest.config.json
@@ -7,7 +7,6 @@
     "^@core(.*)$": "<rootDir>/src/core$1",
 
     "^@services(.*)$": "<rootDir>/src/services$1",
-    "^@network(.*)$": "<rootDir>/src/services/network$1",
 
     "^@extensions(.*)$": "<rootDir>/src/extensions$1",
     "^@components(.*)$": "<rootDir>/src/ui/components$1",

--- a/jest.config.json
+++ b/jest.config.json
@@ -6,13 +6,13 @@
   "moduleNameMapper": {
     "^@core(.*)$": "<rootDir>/src/core$1",
 
-    "^@services(.*)$": "<rootDir>/src/services$1",
-
     "^@extensions(.*)$": "<rootDir>/src/extensions$1",
     "^@components(.*)$": "<rootDir>/src/ui/components$1",
     "^@context(.*)$": "<rootDir>/src/ui/context$1",
     "^@effects(.*)$": "<rootDir>/src/ui/effects$1",
     "^@views(.*)$": "<rootDir>/src/ui/views$1",
+
+    "^@services(.*)$": "<rootDir>/src/services$1",
 
     "^@utils(.*)$": "<rootDir>/src/shared/utils$1",
     "^@translation(.*)$": "<rootDir>/src/shared/translation$1",

--- a/jest.config.json
+++ b/jest.config.json
@@ -8,7 +8,6 @@
 
     "^@services(.*)$": "<rootDir>/src/services$1",
     "^@network(.*)$": "<rootDir>/src/services/network$1",
-    "^@persistence(.*)$": "<rootDir>/src/services/persistence$1",
 
     "^@extensions(.*)$": "<rootDir>/src/extensions$1",
     "^@components(.*)$": "<rootDir>/src/ui/components$1",

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -1,9 +1,7 @@
 import type { GetStaticProps, GetStaticPaths } from "next";
 import type { PostProps } from "@views/Post";
 
-import { notesMetadata } from "@network/metadata";
-import { fetchNote } from "@network/content";
-import { noteNames } from "@network/listing";
+import { notesMetadata, fetchNote, noteNames } from "@services/network";
 import { PostView as BlogPost } from "@views/Post";
 
 export const getStaticProps: GetStaticProps<PostProps> = async (context) => {

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,7 +1,7 @@
 import type { GetStaticProps } from "next";
 import type { BlogProps } from "@views/Blog";
 
-import { notesMetadata } from "@network/metadata";
+import { notesMetadata } from "@services/network";
 import { Blog as BlogPage } from "@views/Blog";
 
 export const getStaticProps: GetStaticProps<BlogProps> = () => {

--- a/src/pages/projects/[id].tsx
+++ b/src/pages/projects/[id].tsx
@@ -1,9 +1,7 @@
 import type { GetStaticProps, GetStaticPaths } from "next";
 import type { PostProps } from "@views/Post";
 
-import { projectsMetadata } from "@network/metadata";
-import { fetchProject } from "@network/content";
-import { projectNames } from "@network/listing";
+import { projectsMetadata, fetchProject, projectNames } from "@services/network";
 import { PostView as ProjectPage } from "@views/Post";
 
 export const getStaticProps: GetStaticProps<PostProps> = async (context) => {

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -1,7 +1,7 @@
 import type { GetStaticProps } from "next";
 import type { ProjectsProps } from "@views/Projects";
 
-import { projectsMetadata } from "@network/metadata";
+import { projectsMetadata } from "@services/network";
 import { Projects as ProjectsPage } from "@views/Projects";
 
 export const getStaticProps: GetStaticProps<ProjectsProps> = () => {

--- a/src/pages/rss.tsx
+++ b/src/pages/rss.tsx
@@ -2,8 +2,7 @@ import type { GetStaticProps } from "next";
 import type { FeedEntry, FeedProps } from "@views/Feed";
 import type { Metadata } from "@core/metadata";
 
-import { notesMetadata } from "@network/metadata";
-import { fetchNote } from "@network/content";
+import { notesMetadata, fetchNote } from "@services/network";
 import { Feed as RssPage } from "@views/Feed";
 
 async function createEntry(metadata: Metadata): Promise<FeedEntry> {

--- a/src/pages/tag/[id].tsx
+++ b/src/pages/tag/[id].tsx
@@ -2,7 +2,7 @@ import type { GetStaticProps, GetStaticPaths } from "next";
 import type { TagKind } from "@core/tags";
 import { tags } from "@core/tags";
 
-import { projectsMetadata, notesMetadata, talksMetadata } from "@network/metadata";
+import { projectsMetadata, notesMetadata, talksMetadata } from "@services/network";
 import { castTo } from "@utils/castTo";
 import { withTag } from "@utils/filter";
 

--- a/src/pages/tag/travel.tsx
+++ b/src/pages/tag/travel.tsx
@@ -2,7 +2,7 @@ import type { GetStaticProps } from "next";
 import type { TravelProps } from "@views/Travel";
 
 import { withTravelTag } from "@utils/filter";
-import { notesMetadata } from "@network/metadata";
+import { notesMetadata } from "@services/network";
 import { Travel as TravelPage } from "@views/Travel";
 
 export const getStaticProps: GetStaticProps<TravelProps> = () => {

--- a/src/pages/talks/[id].tsx
+++ b/src/pages/talks/[id].tsx
@@ -1,9 +1,7 @@
 import type { GetStaticPaths, GetStaticProps } from "next";
 import type { PostProps } from "@views/Post";
 
-import { talksMetadata } from "@network/metadata";
-import { fetchTalk } from "@network/content";
-import { talkNames } from "@network/listing";
+import { talksMetadata, fetchTalk, talkNames } from "@services/network";
 import { PostView as TalkPage } from "@views/Post";
 
 export const getStaticProps: GetStaticProps<PostProps> = async (context) => {

--- a/src/pages/talks/index.tsx
+++ b/src/pages/talks/index.tsx
@@ -1,7 +1,7 @@
 import type { GetStaticProps } from "next";
 import type { TalksProps } from "@views/Talks";
 
-import { talksMetadata } from "@network/metadata";
+import { talksMetadata } from "@services/network";
 import { Talks as TalksPage } from "@views/Talks";
 
 export const getStaticProps: GetStaticProps<TalksProps> = () => {

--- a/src/services/network/composition.ts
+++ b/src/services/network/composition.ts
@@ -1,4 +1,4 @@
-import type { Dependencies } from "@network/dependencies";
+import type { Dependencies } from "./dependencies";
 
 import parse from "gray-matter";
 import { serialize } from "next-mdx-remote/serialize";

--- a/src/services/network/content/composition.ts
+++ b/src/services/network/content/composition.ts
@@ -1,6 +1,6 @@
 import { getNote, getProject, getTalk } from "@services/persistence";
 
-import { dependencies } from "@network/composition";
+import { dependencies } from "../composition";
 import { createFetchContentFactory } from "./content";
 
 const contentFor = createFetchContentFactory(dependencies);

--- a/src/services/network/content/composition.ts
+++ b/src/services/network/content/composition.ts
@@ -1,4 +1,4 @@
-import { getNote, getProject, getTalk } from "@persistence/post";
+import { getNote, getProject, getTalk } from "@services/persistence";
 
 import { dependencies } from "@network/composition";
 import { createFetchContentFactory } from "./content";

--- a/src/services/network/content/content.test.ts
+++ b/src/services/network/content/content.test.ts
@@ -1,5 +1,6 @@
+import type { Dependencies } from "../dependencies";
+
 import { castTo } from "@utils/castTo";
-import { Dependencies } from "@network/dependencies";
 import { createFetchContentFactory } from "./content";
 
 const postId = "test-post-id";

--- a/src/services/network/content/content.ts
+++ b/src/services/network/content/content.ts
@@ -1,7 +1,7 @@
 import type { QueryPost } from "@services/persistence";
 
-import type { Dependencies } from "@network/dependencies";
-import type { FetchContent } from "@network/ports";
+import type { Dependencies } from "../dependencies";
+import type { FetchContent } from "../ports";
 
 type FetchContentBuilder = (query: QueryPost) => FetchContent;
 

--- a/src/services/network/content/content.ts
+++ b/src/services/network/content/content.ts
@@ -1,4 +1,4 @@
-import type { QueryPost } from "@persistence/ports";
+import type { QueryPost } from "@services/persistence";
 
 import type { Dependencies } from "@network/dependencies";
 import type { FetchContent } from "@network/ports";

--- a/src/services/network/dependencies.ts
+++ b/src/services/network/dependencies.ts
@@ -1,4 +1,4 @@
-import type { Parse, Serialize, Settings } from "@network/adapters";
+import type { Parse, Serialize, Settings } from "./adapters";
 
 export type Dependencies = {
   settings: Settings;

--- a/src/services/network/listing.ts
+++ b/src/services/network/listing.ts
@@ -1,4 +1,4 @@
-import type { FetchListing } from "@network/ports";
+import type { FetchListing } from "./ports";
 import { noteList, projectList, talkList } from "@services/persistence";
 
 export const projectNames: FetchListing = projectList;

--- a/src/services/network/listing.ts
+++ b/src/services/network/listing.ts
@@ -1,5 +1,5 @@
 import type { FetchListing } from "@network/ports";
-import { noteList, projectList, talkList } from "@persistence/listing";
+import { noteList, projectList, talkList } from "@services/persistence";
 
 export const projectNames: FetchListing = projectList;
 export const noteNames: FetchListing = noteList;

--- a/src/services/network/metadata/composition.ts
+++ b/src/services/network/metadata/composition.ts
@@ -1,4 +1,4 @@
-import { allNotes, allProjects, allTalks } from "@persistence/posts";
+import { allNotes, allProjects, allTalks } from "@services/persistence";
 
 import { dependencies } from "@network/composition";
 import { createFetchMetadataFactory } from "./metadata";

--- a/src/services/network/metadata/composition.ts
+++ b/src/services/network/metadata/composition.ts
@@ -1,6 +1,6 @@
 import { allNotes, allProjects, allTalks } from "@services/persistence";
 
-import { dependencies } from "@network/composition";
+import { dependencies } from "../composition";
 import { createFetchMetadataFactory } from "./metadata";
 
 const metadataFor = createFetchMetadataFactory(dependencies);

--- a/src/services/network/metadata/metadata.test.ts
+++ b/src/services/network/metadata/metadata.test.ts
@@ -1,4 +1,4 @@
-import type { Dependencies } from "@network/dependencies";
+import type { Dependencies } from "../dependencies";
 
 import { castTo } from "@utils/castTo";
 import { createFetchMetadataFactory } from "./metadata";

--- a/src/services/network/metadata/metadata.ts
+++ b/src/services/network/metadata/metadata.ts
@@ -1,5 +1,5 @@
 import type { Metadata } from "@core/metadata";
-import type { QueryListing } from "@persistence/ports";
+import type { QueryListing } from "@services/persistence";
 
 import type { FetchMetadata } from "@network/ports";
 import type { Dependencies } from "@network/dependencies";

--- a/src/services/network/metadata/metadata.ts
+++ b/src/services/network/metadata/metadata.ts
@@ -1,8 +1,8 @@
 import type { Metadata } from "@core/metadata";
 import type { QueryListing } from "@services/persistence";
 
-import type { FetchMetadata } from "@network/ports";
-import type { Dependencies } from "@network/dependencies";
+import type { FetchMetadata } from "../ports";
+import type { Dependencies } from "../dependencies";
 
 import { byDateDescending } from "@utils/sort";
 

--- a/src/services/network/ports.ts
+++ b/src/services/network/ports.ts
@@ -1,6 +1,6 @@
 import type { Metadata } from "@core/metadata";
 import type { PostId } from "@core/post";
-import type { PostContents } from "@network/types";
+import type { PostContents } from "./types";
 
 export type FetchContent = (id: PostId) => Promise<PostContents>;
 export type FetchListing = () => List<PostId>;

--- a/src/services/persistence/composition.ts
+++ b/src/services/persistence/composition.ts
@@ -1,4 +1,4 @@
-import type { Dependencies } from "@persistence/dependencies";
+import type { Dependencies } from "./dependencies";
 
 import system from "fs";
 import path from "path";

--- a/src/services/persistence/dependencies.ts
+++ b/src/services/persistence/dependencies.ts
@@ -1,4 +1,4 @@
-import type { PathResolver, System } from "@persistence/adapters";
+import type { PathResolver, System } from "./adapters";
 
 export type Dependencies = {
   path: PathResolver;

--- a/src/services/persistence/listing/composition.ts
+++ b/src/services/persistence/listing/composition.ts
@@ -1,4 +1,4 @@
-import { dependencies } from "@persistence/composition";
+import { dependencies } from "../composition";
 import { createListingQueryFactory } from "./listing";
 
 const queryFactory = createListingQueryFactory(dependencies);

--- a/src/services/persistence/listing/listing.test.ts
+++ b/src/services/persistence/listing/listing.test.ts
@@ -1,7 +1,7 @@
 import { mockSystem } from "@testing/mocks";
 
-import type { QueryKind } from "@persistence/types";
-import { dependencies } from "@persistence/composition";
+import type { QueryKind } from "../types";
+import { dependencies } from "../composition";
 import { createListingQueryFactory } from "./listing";
 
 const cases: List<QueryKind> = ["notes", "projects", "talks"];

--- a/src/services/persistence/listing/listing.ts
+++ b/src/services/persistence/listing/listing.ts
@@ -1,8 +1,8 @@
-import type { QueryKind } from "@persistence/types";
-import type { Dependencies } from "@persistence/dependencies";
-import type { QueryListing } from "@persistence/ports";
+import type { QueryKind } from "../types";
+import type { Dependencies } from "../dependencies";
+import type { QueryListing } from "../ports";
 
-import { directoryFor, isMdx } from "@persistence/utils";
+import { directoryFor, isMdx } from "../utils";
 
 type QueryCreator = (query: QueryKind) => QueryListing;
 

--- a/src/services/persistence/ports.ts
+++ b/src/services/persistence/ports.ts
@@ -1,5 +1,5 @@
 import type { PostId } from "@core/post";
-import type { FileContent } from "@persistence/types";
+import type { FileContent } from "./types";
 
 export type QueryListing = () => List<PostId>;
 export type QueryPost = (id: PostId) => FileContent;

--- a/src/services/persistence/post/composition.ts
+++ b/src/services/persistence/post/composition.ts
@@ -1,4 +1,4 @@
-import { dependencies } from "@persistence/composition";
+import { dependencies } from "../composition";
 import { createPostQueryFactory } from "./post";
 
 const queryFactory = createPostQueryFactory(dependencies);

--- a/src/services/persistence/post/post.test.ts
+++ b/src/services/persistence/post/post.test.ts
@@ -1,7 +1,7 @@
 import { mockSystem } from "@testing/mocks";
 
-import type { QueryKind } from "@persistence/types";
-import { dependencies } from "@persistence/composition";
+import type { QueryKind } from "../types";
+import { dependencies } from "../composition";
 import { createPostQueryFactory } from "./post";
 
 const cases: List<QueryKind> = ["notes", "projects", "talks"];

--- a/src/services/persistence/post/post.ts
+++ b/src/services/persistence/post/post.ts
@@ -1,8 +1,8 @@
-import type { QueryPost } from "@persistence/ports";
-import type { QueryKind } from "@persistence/types";
-import type { Dependencies } from "@persistence/dependencies";
+import type { QueryPost } from "../ports";
+import type { QueryKind } from "../types";
+import type { Dependencies } from "../dependencies";
 
-import { directoryFor, withMdx } from "@persistence/utils";
+import { directoryFor, withMdx } from "../utils";
 
 type QueryFactory = (query: QueryKind) => QueryPost;
 

--- a/src/services/persistence/posts/composition.ts
+++ b/src/services/persistence/posts/composition.ts
@@ -1,4 +1,4 @@
-import { dependencies } from "@persistence/composition";
+import { dependencies } from "../composition";
 import { createPostsQueryFactory } from "./posts";
 
 const queryFactory = createPostsQueryFactory(dependencies);

--- a/src/services/persistence/posts/posts.test.ts
+++ b/src/services/persistence/posts/posts.test.ts
@@ -1,7 +1,7 @@
 import { mockSystem } from "@testing/mocks";
 
-import type { QueryKind } from "@persistence/types";
-import { dependencies } from "@persistence/composition";
+import type { QueryKind } from "../types";
+import { dependencies } from "../composition";
 import { createPostsQueryFactory } from "./posts";
 
 const cases: List<QueryKind> = ["notes", "projects", "talks"];

--- a/src/services/persistence/posts/posts.ts
+++ b/src/services/persistence/posts/posts.ts
@@ -1,8 +1,8 @@
-import type { QueryPosts } from "@persistence/ports";
-import type { QueryKind } from "@persistence/types";
-import type { Dependencies } from "@persistence/dependencies";
+import type { QueryPosts } from "../ports";
+import type { QueryKind } from "../types";
+import type { Dependencies } from "../dependencies";
 
-import { directoryFor, isMdx } from "@persistence/utils";
+import { directoryFor, isMdx } from "../utils";
 
 type QueryCreator = (query: QueryKind) => QueryPosts;
 

--- a/src/services/persistence/utils/addExtension.ts
+++ b/src/services/persistence/utils/addExtension.ts
@@ -1,4 +1,4 @@
-import type { FileExtension, FileName } from "@persistence/types";
+import type { FileExtension, FileName } from "../types";
 
 type FileWithoutExtension = FileName;
 type AddExtension = (file: FileWithoutExtension) => `${FileWithoutExtension}.${FileExtension}`;

--- a/src/services/persistence/utils/composition.ts
+++ b/src/services/persistence/utils/composition.ts
@@ -1,4 +1,4 @@
-import { dependencies } from "@persistence/composition";
+import { dependencies } from "../composition";
 
 import { createPathBuilder } from "./directory";
 import { createExtensionChecker } from "./hasExtension";

--- a/src/services/persistence/utils/directory.test.ts
+++ b/src/services/persistence/utils/directory.test.ts
@@ -1,5 +1,5 @@
-import { dependencies } from "@persistence/composition";
-import { QueryKind } from "@persistence/types";
+import { dependencies } from "../composition";
+import { QueryKind } from "../types";
 import { createPathBuilder } from "./directory";
 
 describe("when specified a locale", () => {

--- a/src/services/persistence/utils/directory.ts
+++ b/src/services/persistence/utils/directory.ts
@@ -1,6 +1,6 @@
-import type { ContentDirectory, QueryKind } from "@persistence/types";
-import { Dependencies } from "@persistence/dependencies";
-import { BASE_DIRECTORY } from "@persistence/const";
+import type { ContentDirectory, QueryKind } from "../types";
+import { Dependencies } from "../dependencies";
+import { BASE_DIRECTORY } from "../const";
 
 type DirectoryPathBuilder = (query: QueryKind) => ContentDirectory;
 

--- a/src/services/persistence/utils/hasExtension.ts
+++ b/src/services/persistence/utils/hasExtension.ts
@@ -1,4 +1,4 @@
-import type { FileExtension, FileName } from "@persistence/types";
+import type { FileExtension, FileName } from "../types";
 
 type HasExtension = (file: FileName) => boolean;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
       "@core/*": ["src/core/*"],
 
       "@services/*": ["src/services/*"],
-      "@network/*": ["src/services/network/*"],
 
       "@extensions/*": ["src/extensions/*"],
       "@components/*": ["src/ui/components/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "paths": {
       "@core/*": ["src/core/*"],
 
+      "@services/*": ["src/services/*"],
       "@network/*": ["src/services/network/*"],
       "@persistence/*": ["src/services/persistence/*"],
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,13 +18,13 @@
     "paths": {
       "@core/*": ["src/core/*"],
 
-      "@services/*": ["src/services/*"],
-
       "@extensions/*": ["src/extensions/*"],
       "@components/*": ["src/ui/components/*"],
       "@context/*": ["src/ui/context/*"],
       "@effects/*": ["src/ui/effects/*"],
       "@views/*": ["src/ui/views/*"],
+
+      "@services/*": ["src/services/*"],
 
       "@utils/*": ["src/shared/utils/*"],
       "@styles/*": ["src/shared/styles/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
 
       "@services/*": ["src/services/*"],
       "@network/*": ["src/services/network/*"],
-      "@persistence/*": ["src/services/persistence/*"],
 
       "@extensions/*": ["src/extensions/*"],
       "@components/*": ["src/ui/components/*"],


### PR DESCRIPTION
- When using a service in another, only use the re-exported public API and specified ports.
- Register a `@services` path alias as the root for services instead of each “service as a path”.