### PR TITLE
fix: explicit design 1 TDD example

### DIFF
--- a/storage/en/notes/explicit-design-1.mdx
+++ b/storage/en/notes/explicit-design-1.mdx
@@ -605,14 +605,14 @@ Next, we can describe the tests for the second case, to make sure that the funct
 
 ```ts
 it.each<TestCase>([
-  { base: 10, rate: 1.1, expected: 11 },
+  { base: 10, rate: 1.1, expected: 11.00 },
   { base: 10, rate: 0.725, expected: 7.25 },
 ])("should have a precision of two decimal places", ({ base, rate, expected }) =>
   expect(calculateQuote(base, rate)).toEqual(expected),
 );
 ```
 
-We make sure that the tests fall because there is no rounding. After that we write the implementation:
+We make sure that the tests fall because of rounding. After that we write the implementation:
 
 ```ts
 const calculateQuote: CalculateQuote = (base, rate) => Number((base * rate).toFixed(2));

--- a/storage/en/notes/explicit-design-series.mdx
+++ b/storage/en/notes/explicit-design-series.mdx
@@ -85,7 +85,7 @@ Perhaps the benefits would be more visible in a larger application, but I decide
 
 We will develop the application step by step. The results of each stage of work can be found [on GitHub](https://github.com/bespoyasov/explicit-design). Each post will refer to a separate folder in the project repository, where you can see how everything is organized and play with the code.
 
-The source code of the posts themselves is located in the [repository of my blog](https://github.com/bespoyasov/explicit-design/issues). If you have found a typo, error, or just want to add to the text, send an issue or pull request!
+The source code of the posts themselves is located in the [repository of my blog](https://github.com/bespoyasov/www). If you have found a typo, error, or just want to add to the text, send an issue or pull request!
 
 ## Application Functionality
 

--- a/storage/ru/notes/explicit-design-1.mdx
+++ b/storage/ru/notes/explicit-design-1.mdx
@@ -596,7 +596,7 @@ it.each<TestCase>([
 
 ```ts
 it.each<TestCase>([
-  { base: 10, rate: 1.1, expected: 11 },
+  { base: 10, rate: 1.1, expected: 11.00 },
   { base: 10, rate: 0.725, expected: 7.25 },
 ])("should have a precision of two decimal places", ({ base, rate, expected }) =>
   expect(calculateQuote(base, rate)).toEqual(expected),


### PR DESCRIPTION
Hello,

Thanks for this very insightful series of articles !

I believe the 2nd test given in the [TDD section](https://bespoyasov.me/blog/explicit-design-1/#test-driven-development) of Explicit Design 1 would pass with the first implementation of `calculateQuote` as `10 * 1.1 === 11`.  
If you'd want to test drive the implementation of 2 decimals, I believe you'd have to expect `11.00` as a result of `calculateQuote(10, 1.1)` as this would fail with the first implementation, and pass with the addition of `toFixed(2)`

I've fixed the example in the Russian section as well, but as I've no knowledge in Russian, i've left the text as is.
I'd be more than happy if someone can have a look and check if it needs any changes.

Also batched a small link fix in the introduction post (link of the blog repo was incorrect)

Thanks again !